### PR TITLE
feat: adiciona notebook com visualização passo a passo de caminho mínimo

### DIFF
--- a/Shortest_path.ipynb
+++ b/Shortest_path.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f64caa00",
+   "metadata": {},
+   "source": [
+    "# Caminho Mínimo - Exemplo Visual Passo a Passo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "363a0bb3",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Este notebook demonstra a construção passo a passo de um caminho mínimo em um grafo direcionado com pesos, ilustrando o conceito de que todos os subcaminhos de um caminho mínimo também são mínimos.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f64941d",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Estrutura do Grafo\n",
+    "\n",
+    "O grafo contém os seguintes caminhos:\n",
+    "\n",
+    "- `A → B → C → E` com peso total: **7** ✅\n",
+    "- `A → C → E` com peso total: 14\n",
+    "- `A → D → C → E` com peso total: 8\n",
+    "\n",
+    "Queremos encontrar o caminho mínimo de **A até E**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "467d7671",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import networkx as nx\n",
+    "\n",
+    "G = nx.DiGraph()\n",
+    "G.add_edge(\"A\", \"B\", weight=1)\n",
+    "G.add_edge(\"B\", \"C\", weight=2)\n",
+    "G.add_edge(\"A\", \"C\", weight=10)\n",
+    "G.add_edge(\"A\", \"D\", weight=3)\n",
+    "G.add_edge(\"D\", \"C\", weight=1)\n",
+    "G.add_edge(\"C\", \"E\", weight=4)\n",
+    "\n",
+    "pos = {\n",
+    "    \"A\": (0, 0),\n",
+    "    \"B\": (1, 2),\n",
+    "    \"D\": (1, -2),\n",
+    "    \"C\": (2, 0),\n",
+    "    \"E\": (3, 0)\n",
+    "}\n",
+    "\n",
+    "steps = [\n",
+    "    {\"edges\": [(\"A\", \"B\")], \"title\": \"1º Passo: A → B\"},\n",
+    "    {\"edges\": [(\"A\", \"B\"), (\"B\", \"C\")], \"title\": \"2º Passo: B → C\"},\n",
+    "    {\"edges\": [(\"A\", \"B\"), (\"B\", \"C\"), (\"C\", \"E\")], \"title\": \"3º Passo: C → E\"},\n",
+    "    {\"edges\": [(\"A\", \"B\"), (\"B\", \"C\"), (\"C\", \"E\")], \"title\": \"Caminho Mínimo Final: A → B → C → E\"}\n",
+    "]\n",
+    "\n",
+    "for step in steps:\n",
+    "    fig, ax = plt.subplots(figsize=(7, 5))\n",
+    "    nx.draw(G, pos, with_labels=True, node_color='lightblue', node_size=2000, arrows=True, ax=ax)\n",
+    "    labels = nx.get_edge_attributes(G, 'weight')\n",
+    "    nx.draw_networkx_edge_labels(G, pos, edge_labels=labels, ax=ax)\n",
+    "    nx.draw_networkx_edges(G, pos, edgelist=step[\"edges\"], edge_color='red', width=3, ax=ax)\n",
+    "    ax.set_title(step[\"title\"])\n",
+    "    ax.axis('off')\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe86d16d",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Conclusão\n",
+    "\n",
+    "O caminho mínimo de A até E é `A → B → C → E`, com peso total 7.  \n",
+    "Todos os seus subcaminhos (`A → B`, `B → C`, `C → E`) também são mínimos, o que confirma a propriedade essencial:\n",
+    "\n",
+    "> Todo subcaminho de um caminho mínimo também é um caminho mínimo.\n",
+    "\n",
+    "Esse conceito é usado em diversos algoritmos clássicos de grafos.\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Este Pull Request adiciona o notebook `caminho_minimo_visual.ipynb` com uma demonstração visual do processo de formação de um caminho mínimo em grafos direcionados com pesos.

### Conteúdo:
- Implementação de um grafo com múltiplos caminhos de A até E
- Destacamento visual passo a passo do caminho mínimo `A → B → C → E`
- Utilização de `networkx` e `matplotlib` para construção gráfica
- Aplicação do conceito de estrutura de caminho mínimo (subcaminhos também mínimos)

Esta adição é útil para reforçar o entendimento da estrutura de soluções ótimas no contexto de algoritmos de caminhos mínimos (base para Bellman-Ford, Floyd-Warshall, etc).
